### PR TITLE
Fix error message

### DIFF
--- a/asyncgpio/gpio.py
+++ b/asyncgpio/gpio.py
@@ -124,7 +124,7 @@ class Line:
         if self._state in _IN_USE:
             raise OSError("This line is already in use")
         if self._state == _FREE:
-            raise RuntimeError("You need to call .open() or .event()")
+            raise RuntimeError("You need to call .open() or .monitor()")
         self._line = gpio.lib.gpiod_chip_get_line(self._chip._chip, self._offset)
         if self._line == gpio.ffi.NULL:
             raise OSError("unable to get line")


### PR DESCRIPTION
`.events()` had been renamed to `.monitor()` [some time ago](https://github.com/M-o-a-T/asyncgpio/commit/8f28a1b8a790715e277a5d8e500000570ebf33ea#diff-a8b3f5f23165064a95622b99fd05fd1ef9efc1ad8ab13064064aa93bb9c29887L120).